### PR TITLE
fix: don't occlude home headline

### DIFF
--- a/src/css/app.less
+++ b/src/css/app.less
@@ -49,7 +49,11 @@ body {
 
 .home {
     h1 {
-        margin: 0 0 14px;
+		margin: 0 0 14px;
+
+		@media screen and (min-width: 767px) and (max-width: 992px) {
+			font-size: 41px;
+		}
     }
 
     .form-inline {


### PR DESCRIPTION
Prevent headline from be occluded by navbar at specific screen breakpoint

Closes #15 