### PR TITLE
Fix bootstrap css version to 3.3.7

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-square150x150logo" content="%PUBLIC_URL%/mstile-150x150.png" />
     <meta name="msapplication-wide310x150logo" content="%PUBLIC_URL%/mstile-310x150.png" />
     <meta name="msapplication-square310x310logo" content="%PUBLIC_URL%/mstile-310x310.png" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:200,300,400" rel="stylesheet">
     <title>Keep Network</title>
   </head>


### PR DESCRIPTION
Update to v4 on cdn breaks grid