### PR TITLE
Pageless: Nuke pager  for notify-update git diff

### DIFF
--- a/slack/notify-update.sh
+++ b/slack/notify-update.sh
@@ -5,5 +5,5 @@ if [ $? == 0 ]; then
   curl -XPOST --data "" $GUARDIAN_UPDATE_ENDPOINT
 else
   echo "No Slack updates detected in diff, not issuing a notification."
-  git diff --stat --name-status HEAD^
+  git --no-pager diff --stat --name-status HEAD^
 fi


### PR DESCRIPTION
The git diff call is there for log/debug purposes in case an update
isn't notified that should be, but it was trying to use a pager, which
led to timeouts in Circle when the pager simply blocked the shell until
Circle timed the build out.

Git will no longer use a pager for the diff, so the whole diff should be
spit out to the shell and the Circle build should finish normally even
on long diffs.