### PR TITLE
Docker Press: Point /press to /index.html in docker nginx config

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -17,6 +17,10 @@ http {
             expires 30s;
         }
 
+	location /press {
+	    try_files $uri /index.html;
+	}
+
         listen 80;
     }
 }


### PR DESCRIPTION
![Terrible amalgam of docker logo and french press](https://user-images.githubusercontent.com/8245/67333679-f9b08600-f4ee-11e9-800e-8ac719119283.jpg)

Due to how we're handling routing in the app, `/press` isn't a separate
page, but rather a state of the main page. However, nginx doesn't know
that, so it's trying to resolve a file at `/press` that does not exist.

As with the business primer, `try_files` is used here to allow for
replacing the page with an actual entity at `/press` if needed.