### PR TITLE
Fix nav links from Gatsby refactoring

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
     - if: github.event_name == 'pull_request'
       run: npm run build:prefixed
       env:
-        BRANCH: ${{ github.head_ref }}
+        GATSBY_BRANCH: ${{ github.head_ref }}
     # A push event is a master merge; deploy to primary bucket.
     - if: github.event_name == 'push'
       name: Deploy Master to GCP

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -95,5 +95,5 @@ module.exports = {
     }, // must be after other CSS plugins
     "gatsby-plugin-netlify", // make sure to keep it last in the array
   ],
-  pathPrefix: "/" + process.env["BRANCH"],
+  pathPrefix: "/" + process.env["GATSBY_BRANCH"],
 }

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,7 +3,7 @@ import { Alert } from "reactstrap"
 import PropTypes from "prop-types"
 
 import Footer from "./Footer"
-import NavContent from "./NavContent"
+import Header from "./Header"
 import SEO from "./SEO.js"
 
 import "../css/app.scss"
@@ -11,7 +11,7 @@ import "../css/app.scss"
 const App = ({ children }) => (
   <div className="app has-alert">
     <SEO />
-    <NavContent />
+    <Header />
     {children}
     <Footer />
     <Alert color="info">

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,12 +8,13 @@ import {
   NavbarToggler,
   NavLink,
 } from "reactstrap"
+import { Link } from "gatsby"
 
 import NavScrollItem from "./NavScrollItem"
 import * as Icons from "./Icons"
 import { routes, sections, WHITEPAPER_URL } from "../constants"
 
-const NavContent = () => {
+const Header = () => {
   const [collapsed, setCollapsed] = useState(true)
   const toggleNavbar = () => setCollapsed(!collapsed)
 
@@ -52,7 +53,9 @@ const NavContent = () => {
               Advisors
             </NavScrollItem>
             <NavItem>
-              <NavLink href={routes.PRESS}>Press</NavLink>
+              <Link to={routes.PRESS} activeClassName="active">
+                Press
+              </Link>
             </NavItem>
             <NavItem>
               <NavLink
@@ -70,4 +73,4 @@ const NavContent = () => {
   )
 }
 
-export default NavContent
+export default Header

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -12,7 +12,7 @@ import { Link } from "gatsby"
 
 import NavScrollItem from "./NavScrollItem"
 import * as Icons from "./Icons"
-import { routes, sections, WHITEPAPER_URL } from "../constants"
+import { routes, sections } from "../constants"
 
 const Header = () => {
   const [collapsed, setCollapsed] = useState(true)
@@ -33,15 +33,6 @@ const Header = () => {
         <NavbarToggler onClick={toggleNavbar} />
         <Collapse isOpen={!collapsed} navbar>
           <Nav>
-            <NavItem>
-              <NavLink
-                href={WHITEPAPER_URL}
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                Whitepaper
-              </NavLink>
-            </NavItem>
             <NavScrollItem href={routes.MAIN} to={sections.TEAM} hashSpy={true}>
               Team
             </NavScrollItem>

--- a/src/components/NavScrollItem.js
+++ b/src/components/NavScrollItem.js
@@ -12,14 +12,10 @@ const propTypes = {
   ]),
   className: PropTypes.string,
   hashSpy: PropTypes.bool,
-  history: PropTypes.shape({
-    push: PropTypes.string,
-  }),
   href: PropTypes.string,
   role: PropTypes.string,
   to: PropTypes.string,
   onClick: PropTypes.func,
-  onSelect: PropTypes.func,
   eventKey: PropTypes.any,
   style: PropTypes.object,
   spy: PropTypes.bool,
@@ -37,11 +33,23 @@ const defaultProps = {
   element: "li",
 }
 
-// A Scroll Aware NavItem compatible with React Bootstrap's Nav
-class NavScrollItem extends React.Component {
-  handleClick = (e) => {
-    const { eventKey, onSelect, onClick, href, history, to } = this.props
-
+// A Scroll Aware NavItem compatible
+const NavScrollItem = ({
+  active,
+  className,
+  style,
+  activeClass,
+  href,
+  hashSpy,
+  onClick,
+  to,
+  spy,
+  smooth,
+  duration,
+  children,
+  element: Element,
+}) => {
+  const handleClick = (e) => {
     if (typeof onClick === "function") {
       onClick()
     }
@@ -49,67 +57,29 @@ class NavScrollItem extends React.Component {
     if (href) {
       e.stopPropagation()
 
-      history.push(`${href}#${to || ""}`)
-    }
-
-    if (onSelect) {
-      e.preventDefault()
-
-      onSelect(eventKey, e)
+      window.history.pushState({}, "", `${href}#${to || ""}`)
     }
   }
 
-  render() {
-    const {
-      active,
-      className,
-      style,
-      activeClass,
-      hashSpy,
-      to,
-      spy,
-      smooth,
-      duration,
-      children,
-      element: Element,
-      ...props
-    } = this.props
-
-    delete props.onSelect
-    delete props.eventKey
-
-    // These are injected down by `<Nav>` for building `<SubNav>`s.
-    delete props.activeKey
-    delete props.activeHref
-
-    if (!props.role) {
-      if (props.to === "#") {
-        props.role = "button"
-      }
-    } else if (props.role === "tab") {
-      props["aria-selected"] = active
-    }
-
-    return (
-      <Element
-        role="presentation"
-        className={classNames(className, { active })}
-        style={style}
+  return (
+    <Element
+      role="presentation"
+      className={classNames(className, { active })}
+      style={style}
+    >
+      <Link
+        activeClass={activeClass}
+        to={to}
+        spy={spy}
+        hashSpy={hashSpy}
+        smooth={smooth}
+        duration={duration}
+        onClick={handleClick}
       >
-        <Link
-          activeClass={activeClass}
-          to={to}
-          spy={spy}
-          hashSpy={hashSpy}
-          smooth={smooth}
-          duration={duration}
-          onClick={this.handleClick}
-        >
-          {children}
-        </Link>
-      </Element>
-    )
-  }
+        {children}
+      </Link>
+    </Element>
+  )
 }
 
 NavScrollItem.propTypes = propTypes

--- a/src/components/NavScrollItem.js
+++ b/src/components/NavScrollItem.js
@@ -52,6 +52,9 @@ const NavScrollItem = ({
   element: Element,
 }) => {
   const location = useLocation()
+  const root = process.env.GATSBY_BRANCH
+    ? `/${process.env.GATSBY_BRANCH}/`
+    : "/"
 
   const handleClick = (e) => {
     if (typeof onClick === "function") {
@@ -71,7 +74,7 @@ const NavScrollItem = ({
       className={classNames(className, { active })}
       style={style}
     >
-      {location.pathname === "/" ? (
+      {location.pathname === root ? (
         <ScrollLink
           activeClass={activeClass}
           to={to}

--- a/src/components/NavScrollItem.js
+++ b/src/components/NavScrollItem.js
@@ -1,7 +1,9 @@
 import classNames from "classnames"
 import React from "react"
 import PropTypes from "prop-types"
-import { Link } from "react-scroll"
+import { Link as ScrollLink } from "react-scroll"
+import { Link } from "gatsby"
+import { useLocation } from "@reach/router"
 
 const propTypes = {
   active: PropTypes.bool,
@@ -49,6 +51,8 @@ const NavScrollItem = ({
   children,
   element: Element,
 }) => {
+  const location = useLocation()
+
   const handleClick = (e) => {
     if (typeof onClick === "function") {
       onClick()
@@ -67,17 +71,23 @@ const NavScrollItem = ({
       className={classNames(className, { active })}
       style={style}
     >
-      <Link
-        activeClass={activeClass}
-        to={to}
-        spy={spy}
-        hashSpy={hashSpy}
-        smooth={smooth}
-        duration={duration}
-        onClick={handleClick}
-      >
-        {children}
-      </Link>
+      {location.pathname === "/" ? (
+        <ScrollLink
+          activeClass={activeClass}
+          to={to}
+          spy={spy}
+          hashSpy={hashSpy}
+          smooth={smooth}
+          duration={duration}
+          onClick={handleClick}
+        >
+          {children}
+        </ScrollLink>
+      ) : (
+        <Link activeClassName={activeClass} to={`/#${to}`}>
+          {children}
+        </Link>
+      )}
     </Element>
   )
 }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,10 +1,10 @@
 import App from "./App"
 import EmailForm from "./EmailForm"
 import Footer from "./Footer"
+import Header from "./Header"
 import * as Icons from "./Icons"
 import Image from "./Image"
 import ImageLink from "./ImageLink"
-import NavContent from "./NavContent"
 import NavScrollItem from "./NavScrollItem"
 import PageSection from "./PageSection"
 import PressContent from "./PressContent"
@@ -15,10 +15,10 @@ export {
   App,
   EmailForm,
   Footer,
+  Header,
   Icons,
   Image,
   ImageLink,
-  NavContent,
   NavScrollItem,
   PageSection,
   PressContent,

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -4,7 +4,7 @@
 @import 'mixins';
 @import 'typography';
 @import 'forms';
-@import 'nav';
+@import 'header';
 @import 'timeline';
 @import 'profile';
 @import 'page-section';

--- a/src/css/header.scss
+++ b/src/css/header.scss
@@ -26,7 +26,8 @@
             > a {
                 display: block;
                 font-weight: 400;
-                font-size: 15px;
+                font-size: 13px;
+                letter-spacing: 0.08em;
                 color: $body-text-color;
                 line-height: 20px;
                 text-transform: uppercase;
@@ -34,10 +35,13 @@
                 transition: color, font-weight 0.25s ease-in;
                 position: relative;
 
+                &[href^=http]:after {
+                    content: ' ↗';
+                }
+
                 @media (min-width: #{$bp-medium}) {
                     width: 168px;
-                    border-right: 0.25px solid $border-color;
-                    padding: 15px;
+                    padding: 34px 15px;
 
                     &:hover,
                     &:focus,
@@ -46,19 +50,21 @@
                     &:active:focus,
                     &.active,
                     &.focus {
-                        &:after {
+                        text-decoration: none;
+
+                        &:before {
                             display: block;
                             content: '';
                             width: 100%;
                             height: 3px;
                             position: absolute;
-                            bottom: -4px;
+                            bottom: 0;
                             left: 0;
                         }
                     }
 
                     &:hover {
-                        &:after {
+                        &:before {
                             background-color: $black;
                         }
                     }
@@ -71,7 +77,7 @@
                     &.focus {
                         font-weight: 700;
 
-                        &:after {
+                        &:before {
                             background-color: $link-color;
                         }
                     }
@@ -96,7 +102,7 @@
                     &:active:focus,
                     &.active,
                     &.focus {
-                        &:after {
+                        &:before {
                             display: block;
                             content: '';
                             width: 20px;
@@ -108,7 +114,7 @@
                     }
 
                     &:hover {
-                        &:after {
+                        &:before {
                             background-color: $black;
                         }
                     }
@@ -121,17 +127,9 @@
                     &.focus {
                         font-weight: 700;
 
-                        &:after {
+                        &:before {
                             background-color: $link-color;
                         }
-                    }
-                }
-            }
-
-            &:first-of-type {
-                > a {
-                    @media (min-width: #{$bp-medium}) {
-                        border-left: 0.25px solid $border-color;
                     }
                 }
             }
@@ -162,12 +160,10 @@
         @media (min-width: #{$bp-medium}) {
             margin: 0;
 
-            border-left: 0.25px solid $border-color;
-            border-right: 0.25px solid $border-color;
             svg {
                 height: 25.63px;
                 width: 100px;
-                margin: 12px 40px;
+                margin: 12px 40px 12px 0;
             }
         }
 
@@ -233,7 +229,7 @@
         }
 
         @media only screen and (min-width: 662px) {
-            top: 46px;
+            top: 44px;
         }
     }
 }

--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -43,7 +43,7 @@
     }
 
     @media (min-width: #{$bp-medium}) {
-        padding: 140px 0 0;
+        padding: 170px 0 0;
     }
 
     @media (max-width: #{($bp-medium - 1)}) {


### PR DESCRIPTION
Note: #180 needs to be reviewed first. 

Updates the `NavScrollItem` component to only use scrollable hash links if the current page is the home page. If it is not the home page, these links will use Gatsby's `Link` component.

Also removes the whitepaper link and updates the nav to the latest designs.