### PR TITLE
Final cms tweaks

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -34,9 +34,7 @@ export const FooterTemplate = ({
             <ul>
               {dropdown.dropdown_items.map((item, j) => (
                 <li key={`nav-dropdown-item-${j}`}>
-                  <Link url={item.url} isExternal={item.is_external_link}>
-                    {item.label}
-                  </Link>
+                  <Link url={item.url}>{item.label}</Link>
                 </li>
               ))}
             </ul>
@@ -92,7 +90,6 @@ export const query = graphql`
               title
               dropdown_items {
                 label
-                is_external_link
                 url
               }
             }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -10,7 +10,7 @@ import Link from "./Link"
 export const FooterTemplate = ({
   images = {},
   emailLink = {},
-  dropdowns = [],
+  navCategories = [],
   copyright = "",
   legalLinks = [],
 }) => (
@@ -25,15 +25,15 @@ export const FooterTemplate = ({
             </Button>
           </li>
         </ul>
-        {dropdowns.map((dropdown, i) => (
+        {navCategories.map((category, i) => (
           <CollapsibleList
-            key={`nav-dropdown-${i}`}
-            label={dropdown.title}
+            key={`nav-category-${i}`}
+            label={category.title}
             className={`footer-column-${i + 2}`}
           >
             <ul>
-              {dropdown.dropdown_items.map((item, j) => (
-                <li key={`nav-dropdown-item-${j}`}>
+              {category.items.map((item, j) => (
+                <li key={`nav-category-item-${j}`}>
                   <Link url={item.url}>{item.label}</Link>
                 </li>
               ))}
@@ -62,7 +62,7 @@ export const FooterTemplate = ({
 FooterTemplate.propTypes = {
   images: PropTypes.object,
   emailLink: PropTypes.object,
-  dropdowns: PropTypes.array,
+  navCategories: PropTypes.array,
   copyright: PropTypes.string,
   legalLinks: PropTypes.array,
 }
@@ -86,9 +86,9 @@ export const query = graphql`
               label
               email
             }
-            nav_dropdowns {
+            nav_categories {
               title
-              dropdown_items {
+              items {
                 label
                 url
               }
@@ -115,7 +115,7 @@ const Footer = () => (
         <FooterTemplate
           images={{ halfCircle }}
           emailLink={frontmatter.email_link}
-          dropdowns={frontmatter.nav_dropdowns}
+          navCategories={frontmatter.nav_categories}
           copyright={frontmatter.copyright_text}
           legalLinks={frontmatter.legal_links}
         />

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -68,6 +68,7 @@ export const HeaderTemplate = ({ navItems = [] }) => {
           >
             <Icons.Keep height="61px" width="235px" />
           </NavScrollItem>
+          {/* Mobile nav hamburger button */}
           <NavbarToggler onClick={toggleNavbar} />
           <Collapse isOpen={!collapsed} navbar>
             <Nav>
@@ -86,7 +87,6 @@ HeaderTemplate.propTypes = {
   navItems: PropTypes.array,
 }
 
-// Query for Header
 export const query = graphql`
   query Header {
     allMarkdownRemark(

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -14,8 +14,9 @@ import Announcement from "./Announcement"
 import NavScrollItem from "./NavScrollItem"
 import * as Icons from "./Icons"
 
-const NavItem = ({ is_external_link: isExternal, label, url }) => {
-  if (isExternal) {
+const NavItem = ({ label, url }) => {
+  // Test if url is an external link
+  if (/^http/.test(url)) {
     return (
       <li className="nav-item">
         <NavLink href={url} rel="noopener noreferrer" target="_blank">
@@ -45,7 +46,6 @@ const NavItem = ({ is_external_link: isExternal, label, url }) => {
 }
 
 NavItem.propTypes = {
-  is_external_link: PropTypes.bool,
   label: PropTypes.string,
   url: PropTypes.string,
 }
@@ -97,7 +97,6 @@ export const query = graphql`
           frontmatter {
             nav_items {
               label
-              is_external_link
               url
             }
           }

--- a/src/components/Icons.js
+++ b/src/components/Icons.js
@@ -54,27 +54,6 @@ ArrowRight.defaultProps = {
   width: "56",
 }
 
-export const ArrowNorthEast = ({ size = 19, color = "#0A0806" }) => (
-  <svg
-    width={size}
-    height={size}
-    fill="none"
-    viewBox="0 0 19 19"
-    aria-labelledby="arrow-north-east-title"
-  >
-    <title id="arrow-north-east-title">North East Arrow Icon</title>
-    <path
-      fill={color}
-      d="M13.04 13.02l-.058-5.883-8.083 8.082-1.118-1.118 8.082-8.083L5.98 5.96l-.02-1.6 8.7-.02-.02 8.7-1.6-.02z"
-    ></path>
-  </svg>
-)
-
-ArrowNorthEast.propTypes = {
-  color: PropTypes.string,
-  size: PropTypes.number,
-}
-
 export const Axe = ({ height, width }) => (
   <svg
     width={width}

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -2,8 +2,8 @@ import React from "react"
 import { Link as GatsbyLink } from "gatsby"
 import PropTypes from "prop-types"
 
-const Link = ({ isExternal = false, url, children, ...props }) => {
-  if (isExternal || /^http/.test(url)) {
+const Link = ({ url, children, ...props }) => {
+  if (/^http/.test(url)) {
     return (
       <a href={url} rel="noopener noreferrer" target="_blank" {...props}>
         {children}
@@ -19,7 +19,6 @@ const Link = ({ isExternal = false, url, children, ...props }) => {
 }
 
 Link.propTypes = {
-  isExternal: PropTypes.bool,
   url: PropTypes.string,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),

--- a/src/components/NavScrollItem.js
+++ b/src/components/NavScrollItem.js
@@ -1,4 +1,3 @@
-import classNames from "classnames"
 import React from "react"
 import PropTypes from "prop-types"
 import { Link as ScrollLink } from "react-scroll"
@@ -67,11 +66,7 @@ const NavScrollItem = ({
   }
 
   return (
-    <Element
-      role="presentation"
-      className={classNames(className, { active })}
-      style={style}
-    >
+    <Element role="presentation" className={className} style={style}>
       {location.pathname === root ? (
         <ScrollLink
           activeClass={activeClass}

--- a/src/components/NavScrollItem.js
+++ b/src/components/NavScrollItem.js
@@ -2,7 +2,7 @@ import classNames from "classnames"
 import React from "react"
 import PropTypes from "prop-types"
 import { Link as ScrollLink } from "react-scroll"
-import { Link } from "gatsby"
+import { Link, withPrefix } from "gatsby"
 import { useLocation } from "@reach/router"
 
 const propTypes = {
@@ -52,9 +52,7 @@ const NavScrollItem = ({
   element: Element,
 }) => {
   const location = useLocation()
-  const root = process.env.GATSBY_BRANCH
-    ? `/${process.env.GATSBY_BRANCH}/`
-    : "/"
+  const root = withPrefix("/")
 
   const handleClick = (e) => {
     if (typeof onClick === "function") {
@@ -64,7 +62,7 @@ const NavScrollItem = ({
     if (href) {
       e.stopPropagation()
 
-      window.history.pushState({}, "", `${href}#${to || ""}`)
+      window.history.pushState({}, "", withPrefix(`/${href}#${to || ""}`))
     }
   }
 

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -50,6 +50,12 @@ const SEO = ({ title, description, image, pathname, article }) => (
               href="https://fonts.googleapis.com/css?family=Work+Sans:400,500,600,700,800"
               rel="stylesheet"
             />
+            {/* Import arrow glyphs (not included by default and not specified in any subset)
+            See https://stackoverflow.com/questions/40822458/styled-unicode-arrows-not-showing-up-with-google-fonts-web-font */}
+            <link
+              href="https://fonts.googleapis.com/css?family=Work+Sans:400,500,600,700,800&text=%E2%86%90|%E2%86%92|%E2%86%97"
+              rel="stylesheet"
+            />
           </Helmet>
         </>
       )

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -135,7 +135,9 @@ footer {
             .footer-column-1 {
                 flex: 0 0 auto;
                 order: 0;
-                flex-direction: column;
+                display: inline-block;
+                width: auto;
+                max-width: 30%;
                 padding: 0 30px 30px;
             }
 
@@ -154,6 +156,7 @@ footer {
                     font-weight: normal;
                     padding: 9px 24px;
                     margin: 1.5em 0 0;
+                    width: auto;
                 }
             }
         }

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -161,10 +161,10 @@ footer {
             }
         }
 
+        // Desktop uses a different logo than mobile
         .keep-logo {
             height: 65px;
             background-image: url(../images/Keep-logo-circle.svg);
-            background-repeat: no-repeat;
             background-position: top left;
             background-size: contain;
         }

--- a/src/css/press.scss
+++ b/src/css/press.scss
@@ -7,7 +7,7 @@
     }
 
     h2 {
-        font-family: Vitesse;
+        font-family: 'Vitesse', 'Work Sans', sans-serif;
         font-weight: normal;
         font-size: 40px;
         line-height: 1.2;

--- a/src/footer/index.md
+++ b/src/footer/index.md
@@ -3,9 +3,9 @@ template: footer-nav
 email_link:
   label: Email Us
   email: work@keep.network
-nav_dropdowns:
+nav_categories:
   - title: Company
-    dropdown_items:
+    items:
       - label: Whitepaper
         url: https://backend.keep.network/whitepaper
       - label: Team
@@ -13,7 +13,7 @@ nav_dropdowns:
       - label: Advisors
         url: /#advisors
   - title: Follow
-    dropdown_items:
+    items:
       - label: Press
         url: /press
       - label: Twitter
@@ -25,7 +25,7 @@ nav_dropdowns:
       - label: Blog
         url: https://blog.keep.network/
   - title: Community
-    dropdown_items:
+    items:
       - label: Discord
         url: https://discordapp.com/invite/wYezN7v
       - label: GitHub

--- a/src/footer/index.md
+++ b/src/footer/index.md
@@ -17,24 +17,18 @@ nav_dropdowns:
       - label: Press
         url: /press
       - label: Twitter
-        is_external_link: true
         url: https://twitter.com/keep_project
       - label: Telegram
-        is_external_link: true
         url: https://t.me/KeepNetworkOfficial/
       - label: Reddit
-        is_external_link: true
         url: https://www.reddit.com/r/KeepNetwork/
       - label: Blog
-        is_external_link: true
         url: https://blog.keep.network/
   - title: Community
     dropdown_items:
       - label: Discord
-        is_external_link: true
         url: https://discordapp.com/invite/wYezN7v
       - label: GitHub
-        is_external_link: true
         url: https://github.com/keep-network/
 copyright_text: >-
   <p>A Thesis<sup>*</sup> Build</p><p>© 2020 Keep SEZC. All Rights Reserved.</p>

--- a/src/footer/index.md
+++ b/src/footer/index.md
@@ -7,7 +7,7 @@ nav_dropdowns:
   - title: Company
     dropdown_items:
       - label: Whitepaper
-        url: /whitepaper
+        url: https://backend.keep.network/whitepaper
       - label: Team
         url: /#team
       - label: Advisors

--- a/src/header/nav.md
+++ b/src/header/nav.md
@@ -8,6 +8,5 @@ nav_items:
   - label: Press
     url: /press
   - label: Blog
-    is_external_link: true
     url: https://blog.keep.network/
 ---

--- a/src/templates/press-page.js
+++ b/src/templates/press-page.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types"
 import { withPrefix, graphql } from "gatsby"
 
 import { App, Image, PageSection } from "../components"
-import { ArrowRight, ArrowNorthEast } from "../components/Icons"
+import { ArrowRight } from "../components/Icons"
 
 const PressItem = ({ title, date, source, aboveTheFold, url }) => {
   const [windowWidth, setWindowWidth] = useState(0)
@@ -31,9 +31,7 @@ const PressItem = ({ title, date, source, aboveTheFold, url }) => {
               buttons={false}
             />
           </div>
-          <div className="view-arrow">
-            View <ArrowNorthEast />
-          </div>
+          <div className="view-arrow">View &#x2197;</div>
         </div>
       </div>
     </a>

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -308,15 +308,15 @@ collections:
             fields:
               - {label: "Label", name: "label", widget: "string"}
               - {label: "Email Address", name: "email", widget: "string"}
-          - label: "Nav Dropdowns"
-            name: "nav_dropdowns"
+          - label: "Nav Categories"
+            name: "nav_categories"
             widget: "list"
             allow_add: true
             fields:
               - {label: "Title", name: "title", widget: "string"}
               - {
-                label: "Dropdown Items",
-                name: "dropdown_items",
+                label: "Items",
+                name: "items",
                 widget: "list",
                 allow_add: true,
                 fields:

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -287,12 +287,6 @@ collections:
               [
                 { label: "Label", name: "label", widget: "string" },
                 {
-                  label: "External Link",
-                  name: "is_external_link",
-                  widget: "boolean",
-                  default: false
-                },
-                {
                   label: "URL",
                   name: "url",
                   widget: "string",
@@ -328,12 +322,6 @@ collections:
                 fields:
                   [
                     { label: "Label", name: "label", widget: "string" },
-                    {
-                      label: "External Link",
-                      name: "is_external_link",
-                      widget: "boolean",
-                      default: false
-                    },
                     {
                       label: "URL",
                       name: "url",


### PR DESCRIPTION
Pitter patter, lets get at’er.

This addresses some little bugs and nits from the last few CMS related PRs that we need before we can merge to master.

- Use font glyphs for external link arrows instead of inline-svg
- Fix how `NavScrollItem` updates the url for preview builds
- Fix the whitepaper link in the footer
- Address misc notes from the last few PRs