### PR TITLE
Fix typo in cms config

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -130,7 +130,7 @@ collections:
                   ],
               }
           - label: "Supporters Section"
-            name: "supperters_section"
+            name: "supporters_section"
             widget: "object"
             fields:
               - {label: "Title", name: "title", widget: "string"}


### PR DESCRIPTION
This typo was preventing the supporters section data from correctly appearing in the admin view for the home page, and thereby blocked new edits because required data was missing.