### PR TITLE
Feat(UI)/SRT-34: Landing Page UI fixes

### DIFF
--- a/src/css/home.scss
+++ b/src/css/home.scss
@@ -30,6 +30,10 @@
   padding: 72px 0 0;
   min-height: 100vh;
 
+  h1  {
+    margin-top: 48px;
+  }
+
   &-video-bg {
     position: absolute;
     left: 0;


### PR DESCRIPTION
48px margin added to the top of the hero title on landing page as requested in the ticket.