### PR TITLE
Fix discord and blog links

### DIFF
--- a/src/pages/build.md
+++ b/src/pages/build.md
@@ -9,7 +9,7 @@ hero:
   image: /images/build.png
   cta_buttons:
     - label: Join Our Discord
-      url: https://dashboard.keep.network/
+      url: https://discord.com/invite/wYezN7v
 library:
   title: Keep resources
   body: Learn more about building, designing, and staking on the Keep network.

--- a/src/pages/build.md
+++ b/src/pages/build.md
@@ -104,7 +104,7 @@ contact:
         alt: Read the Keep blog
       link:
         name: Read Blog
-        url: https://www.fabric.vc/
+        url: https://blog.keep.network/
     - title: Join the community
       body: Connect with the Discord community, ask questions, and get in on the
         ground level for the future of DeFi.
@@ -113,5 +113,5 @@ contact:
         alt: Join the community
       link:
         name: Join Discord
-        url: https://www.fabric.vc/
+        url: https://discord.com/invite/wYezN7v
 ---

--- a/src/pages/faq.md
+++ b/src/pages/faq.md
@@ -37,7 +37,7 @@ contact:
         alt: Read the Keep blog
       link:
         name: Read Blog
-        url: https://www.fabric.vc/
+        url: https://blog.keep.network/
     - title: Join the community
       body: Connect with the Discord community, ask questions, and get in on the ground level for the future of DeFi.
       icon:
@@ -45,5 +45,5 @@ contact:
         alt: Join the community
       link:
         name: Join Discord
-        url: https://www.fabric.vc/
+        url: https://discord.com/invite/wYezN7v
 ---


### PR DESCRIPTION
Fixes incorrect discord and blog links on `/build` & `/faq`. 

note: `/build` is set to change to `/join` in #448 