### PR TITLE
Fix discord/blog link on Info page

### DIFF
--- a/src/pages/info.md
+++ b/src/pages/info.md
@@ -96,7 +96,7 @@ contact:
         alt: Read the Keep blog
       link:
         name: Read Blog
-        url: https://www.fabric.vc/
+        url: https://blog.keep.network/
     - title: Join the community
       body: Connect with the Discord community, ask questions, and get in on the
         ground level for the future of DeFi.
@@ -105,5 +105,5 @@ contact:
         alt: Join the community
       link:
         name: Join Discord
-        url: https://www.fabric.vc/
+        url: https://discordapp.com/invite/wYezN7v
 ---


### PR DESCRIPTION
Fixes incorrect discord and blog links on `/info` page.