### PR TITLE
Remove APY calc & components from homepage

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -2,7 +2,7 @@
 template: home-page
 path: /
 hero:
-  title: Stake on Ethereum’s first private computer and earn up to
+  title: Stake on Ethereum’s first private computer and earn.
   body: Staking with Keep is the best way to back a truly decentralized network
     and the future of DeFi.
   bg_video: images/home/keep-castle-clouds.mp4

--- a/src/templates/home-page.js
+++ b/src/templates/home-page.js
@@ -12,7 +12,6 @@ import {
   ImageLink,
   Link,
   PageSection,
-  Ticker,
   SummaryGrid,
   MiniLogoWall,
   KeepBlog,
@@ -20,9 +19,7 @@ import {
 } from "../components"
 import { sections } from "../constants"
 import { actions } from "../redux"
-import useLiquidityRewardsAPY from "../hooks/useLiquidityRewardsAPY"
-import LoadingBlocks from "../components/LoadingBlocks"
-import SlideInAnimation from "../components/SlideInAnimation"
+// import useLiquidityRewardsAPY from "../hooks/useLiquidityRewardsAPY"
 import GovernanceForum from "../components/GovernanceForum"
 
 export const HomePageTemplate = ({
@@ -42,19 +39,21 @@ export const HomePageTemplate = ({
     Aos.init({ once: true })
   }, [])
 
-  const [liquidityRewardsAPYs, isFetching] = useLiquidityRewardsAPY()
+  // NOTE/TODO: The APY Calculation has been taken down until we can replace it with a cached server call
 
-  const renderHighestAPY = () => {
-    if (liquidityRewardsAPYs.length === 0) {
-      return <LoadingBlocks numberOfBlocks={3} animationDurationInSec={1} />
-    }
+  // const [liquidityRewardsAPYs, isFetching] = useLiquidityRewardsAPY()
 
-    return (
-      <SlideInAnimation durationInSec={1}>
-        {Math.floor(liquidityRewardsAPYs[0].value).toString()}
-      </SlideInAnimation>
-    )
-  }
+  // const renderHighestAPY = () => {
+  //   if (liquidityRewardsAPYs.length === 0) {
+  //     return <LoadingBlocks numberOfBlocks={3} animationDurationInSec={1} />
+  //   }
+
+  //   return (
+  //     <SlideInAnimation durationInSec={1}>
+  //       {Math.floor(liquidityRewardsAPYs[0].value).toString()}
+  //     </SlideInAnimation>
+  //   )
+  // }
 
   return (
     <div className="main-content">
@@ -69,8 +68,6 @@ export const HomePageTemplate = ({
           <Col xs={12} lg={10} md={10}>
             <h1>
               <span>{`${hero.title} `}</span>
-              {renderHighestAPY()}
-              <span>{`% APY.`}</span>
             </h1>
             <h4 className="body">{hero.body}</h4>
           </Col>
@@ -89,13 +86,6 @@ export const HomePageTemplate = ({
             ))}
           </ul>
         </Row>
-        {!isFetching && (
-          <Ticker
-            items={liquidityRewardsAPYs.map((_) => ({
-              label: `${_.value}% APY · ${_.pool} POOL`,
-            }))}
-          />
-        )}
       </PageSection>
       <PageSection
         id={sections.home.KEEP_SOLUTION}


### PR DESCRIPTION
Removing the APY calculation and components from the homepage until we can move the logic to the server.