### PR TITLE
open links in new tab + noopener noreferrer

### DIFF
--- a/static/when_is_the_tBTC_ICO.html
+++ b/static/when_is_the_tBTC_ICO.html
@@ -5,21 +5,21 @@
 
 <h1>When is the tBTC ICO?</h1>
 <h2><i>Keep and tBTC’s stakedrop will let people stake ETH to earn KEEP</i></h2>
-<p>On June 8th 2020, Keep’s stakedrop -- which will ultimately let people stake ETH to earn KEEP -- officially launched with <a href="https://www.crowdcast.io/e/keep-stakedrop---live" >a public Crowdcast event</a>. The livestream included a keynote from project lead Matt Luongo, a walkthrough, and an overview of next steps. Over the coming weeks there will be additional updates as the stakedrop progresses, including the release of the Keep dashboard and tBTC dapp.</p>
+<p>On June 8th 2020, Keep’s stakedrop -- which will ultimately let people stake ETH to earn KEEP -- officially launched with <a href="https://www.crowdcast.io/e/keep-stakedrop---live" target="_blank" rel="noopener noreferrer">a public Crowdcast event</a>. The livestream included a keynote from project lead Matt Luongo, a walkthrough, and an overview of next steps. Over the coming weeks there will be additional updates as the stakedrop progresses, including the release of the Keep dashboard and tBTC dapp.</p>
 
-<p><b><a href="https://discord.gg/wYezN7v">Join the Discord channel</a> for updates on everything related to Keep and tBTC.</b></p>
+<p><b><a href="https://discord.gg/wYezN7v" target="_blank" rel="noopener noreferrer">Join the Discord channel</a> for updates on everything related to Keep and tBTC.</b></p>
 
 <p>Those who were unable to attend -- or simply want to see it again --  <a href="https://www.crowdcast.io/e/keep-stakedrop---live">the recording is available to re-watch here.</a></p>
 
-<p>tBTC is a project of <a href="https://keep.network/">Keep</a>, <a href="http://summa.one">Summa</a> and the <a href="https://crosschain.group/">Cross-Chain Group</a>. Its trust-minimized design uses a system of random groups of “signers” to process transactions. These groups are selected by a random beacon, minimizing counterparty risk. tBTC uses threshold ECDSA, which is audited and used by major crypto wallets and exchanges including Binance. Users can track their BTC at all times. And because tBTC is open source, the code and fee structure are transparent.</p>
+<p>tBTC is a project of <a href="https://keep.network/">Keep</a>, <a href="http://summa.one">Summa</a> and the <a href="https://crosschain.group/" target="_blank" rel="noopener noreferrer"">Cross-Chain Group</a>. Its trust-minimized design uses a system of random groups of “signers” to process transactions. These groups are selected by a random beacon, minimizing counterparty risk. tBTC uses threshold ECDSA, which is audited and used by major crypto wallets and exchanges including Binance. Users can track their BTC at all times. And because tBTC is open source, the code and fee structure are transparent.</p>
 
-<p>The stakedrop is Keep’s public distribution mechanism for the KEEP work token. 20% of KEEP’s total supply will be distributed in the stakedrop. Since <a href="https://blog.keep.network/the-importance-of-randomness-keeps-role-in-tbtc-a20e444d285b">Keep handles custodianship for tBTC</a>, those acting as signers normally need to stake both KEEP and ETH to perform their tasks. The stakedrop will allow people with no KEEP to act as tBTC signers using only their ETH, with the corresponding KEEP tokens “dropped” to them as a reward over time. The next several months of the stakedrop will see additional milestones including the release of the tBTC dashboard later this month.</p>
+<p>The stakedrop is Keep’s public distribution mechanism for the KEEP work token. 20% of KEEP’s total supply will be distributed in the stakedrop. Since <a href="https://blog.keep.network/the-importance-of-randomness-keeps-role-in-tbtc-a20e444d285b" target="_blank" rel="noopener noreferrer">Keep handles custodianship for tBTC</a>, those acting as signers normally need to stake both KEEP and ETH to perform their tasks. The stakedrop will allow people with no KEEP to act as tBTC signers using only their ETH, with the corresponding KEEP tokens “dropped” to them as a reward over time. The next several months of the stakedrop will see additional milestones including the release of the tBTC dashboard later this month.</p>
 
 <h3>Playing for Keeps Update</h3>
 
-<p>In addition to the stakedrop, <a href="https://blog.keep.network/how-to-play-for-keeps-297f246455d4">Playing for Keeps</a> allows people to earn KEEP tokens for contributing to the network. Each month will see a different judge, who will award 1 million or more KEEP based on specific criteria for improving the network.</p>
+<p>In addition to the stakedrop, <a href="https://blog.keep.network/how-to-play-for-keeps-297f246455d4" target="_blank" rel="noopener noreferrer">Playing for Keeps</a> allows people to earn KEEP tokens for contributing to the network. Each month will see a different judge, who will award 1 million or more KEEP based on specific criteria for improving the network.</p>
 
-<p><a href="https://discord.gg/wYezN7v">Join the Discord</a>: In order to qualify a submission for Playing for Keeps prizes, participants must join the Discord server and provide an overview of themselves in the introduction message. </p>
+<p><a href="https://discord.gg/wYezN7v" target="_blank" rel="noopener noreferrer">Join the Discord</a>: In order to qualify a submission for Playing for Keeps prizes, participants must join the Discord server and provide an overview of themselves in the introduction message. </p>
 
 <p><b>Submit a Play for Keeps entry message in #introduce-yourself which includes:</b> 
 - A name by which users wish to be addressed in the channel
@@ -27,12 +27,12 @@
 - What is being submitted for Playing for Keeps prizes - This can be just an idea
 - If the participant has already produced something they want to submit as an entry</p>
 
-<p>More details about entry requirements are available <a href="https://blog.keep.network/how-to-play-for-keeps-297f246455d4">here.</a></p>
+<p>More details about entry requirements are available <a href="https://blog.keep.network/how-to-play-for-keeps-297f246455d4" target="_blank" rel="noopener noreferrer">here.</a></p>
 
 <h3>The safe way to earn with BTC</h3>
 
 <p>tBTC is designed as the safe way for people to use their BTC to participate in Ethereum DeFi projects. Over the coming months, the launch of the dApp will continue through succeeding release candidates. The ultimate goal is to deliver a project that meets the highest standards of safety and performance to bring <a href="https://coinmarketcap.com/charts/">the three quarters of crypto currently held in Bitcoin</a> off the sidelines and onto growing DeFi platforms.</p>
 
-<p>Stay up-to-date on everything related to tBTC and the stakedrop by joining <a href="https://discord.gg/wYezN7v">the Discord channel.</a></p>
+<p>Stay up-to-date on everything related to tBTC and the stakedrop by joining <a href="https://discord.gg/wYezN7v" target="_blank" rel="noopener noreferrer">the Discord channel.</a></p>
 </body>
 </html>


### PR DESCRIPTION


_blank | Opens the linked document in a new window or tab
-- | --


`rel="noopener"` prevents the new page from being able to access the window.opener property and ensures it runs in a separate process.
`rel="noreferrer"`  has the same effect but also prevents the Referer header from being sent to the new page.